### PR TITLE
Update Link Titling by client

### DIFF
--- a/client/components/Modal/AddLink.vue
+++ b/client/components/Modal/AddLink.vue
@@ -1,6 +1,11 @@
 <template>
   <Modal class="add-modal" overflow="visible" @close="close">
-    <h1>Add a new Link</h1>
+    <input
+      v-model="linkTitle"
+      class="no-input headline"
+      placeholder="Link Name (optional)"
+      title="Click to edit title"
+    />
     <input v-model="inputValue" v-focus class="input" :class="{ 'input-invalid': invalidLinkErr }" placeholder="https://piedpiper.com">
     <div class="dropdown">
       <v-select
@@ -29,7 +34,8 @@ export default {
 		return {
 			selectedCrate: undefined,
 			invalidLinkErr: undefined,
-			isOpen: false
+			isOpen: false,
+			linkTitle: ''
 		}
 	},
 	computed: {
@@ -65,10 +71,11 @@ export default {
 				this.invalidLinkErr = 'Please enter a valid URL'
 				return
 			}
+			const title = this.linkTitle
 
 			const crate = this.selectedCrate || this.currentCrate
 
-			this.$store.dispatch('ADD_LINK', { url, crate }).then((link) => {
+			this.$store.dispatch('ADD_LINK', { title, url, crate }).then((link) => {
 				this.$toast.success('Link added!', {
 					onClick: () => {
 						if (crate !== undefined && crate !== this.currentCrate) {
@@ -129,5 +136,13 @@ export default {
 			margin-bottom: 1rem;
 			font-size: 0.9rem;
 		}
+        .no-input {
+            width: 100%;
+        }
+        .headline {
+            font-size: 1.2rem;
+            font-weight: 700;
+            margin-bottom: 1rem;
+        }
 	}
 </style>

--- a/client/components/Modal/LinkDetails.vue
+++ b/client/components/Modal/LinkDetails.vue
@@ -14,7 +14,7 @@
           <input
             v-if="editable"
             v-model="linkTitle"
-            class="input headline"
+            class="no-input headline"
             placeholder="Click to add a title for this link"
             title="Click to edit title"
           />
@@ -398,9 +398,8 @@ export default {
 		}
 
 		.top {
-            align-items: flex-start;
 			display: flex;
-            column-gap: 25px;
+			align-items: center;
 			margin-bottom: 0.5rem;
 
 			.title {
@@ -419,10 +418,9 @@ export default {
 		}
 
 		.headline {
-            color: var(--text);
 			font-size: inherit;
 			font-weight: 600;
-            margin-bottom: 10px;
+			color: var(--text);
 			width: 100%;
 		}
 

--- a/client/components/Modal/LinkDetails.vue
+++ b/client/components/Modal/LinkDetails.vue
@@ -14,7 +14,7 @@
           <input
             v-if="editable"
             v-model="linkTitle"
-            class="no-input headline"
+            class="input headline"
             placeholder="Click to add a title for this link"
             title="Click to edit title"
           />
@@ -398,8 +398,9 @@ export default {
 		}
 
 		.top {
+            align-items: flex-start;
 			display: flex;
-			align-items: center;
+            column-gap: 25px;
 			margin-bottom: 0.5rem;
 
 			.title {
@@ -418,9 +419,10 @@ export default {
 		}
 
 		.headline {
+            color: var(--text);
 			font-size: inherit;
 			font-weight: 600;
-			color: var(--text);
+            margin-bottom: 10px;
 			width: 100%;
 		}
 

--- a/client/plugins/api.js
+++ b/client/plugins/api.js
@@ -77,10 +77,11 @@ class API {
 		return res
 	}
 
-	async addLinkToCrate(url, crate) {
+	async addLinkToCrate(title, url, crate) {
 		if (this.publicMode) return undefined
 
 		const { data: res } = await this.http.post(`/link`, {
+			title,
 			url,
 			crate
 		})

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -107,8 +107,8 @@ export const actions = {
 
 		commit('SET_CONFIG', config)
 	},
-	async ADD_LINK({ commit }, { url, crate }) {
-		const link = await this.$api.addLinkToCrate(url, crate)
+	async ADD_LINK({ commit }, { title, url, crate }) {
+		const link = await this.$api.addLinkToCrate(title, url, crate)
 
 		commit('ADD_CURRENT_CRATE_LINK', link)
 

--- a/server/router/api/link.ts
+++ b/server/router/api/link.ts
@@ -14,7 +14,7 @@ export const router = express.Router()
 
 router.post('/', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
 	try {
-		const { url, crate } = req.body
+		const { title, url, crate } = req.body
 		if (!url) {
 			return res.fail(400, 'no url provided')
 		}
@@ -31,6 +31,9 @@ router.post('/', async (req: express.Request, res: express.Response, next: expre
 			meta = await getMetaData(parsedUrl, {
 				...(useGoogleUa && { ua: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' })
 			})
+
+			// Add title to meta object
+			if (title) meta.title = title
 		} catch (err) {
 			log.debug(err)
 		}


### PR DESCRIPTION
Here is a small (mostly UX) Feature which I think which improves the User Experience by giving more control of a link to the user.

The Problem: Sometimes I create a Link but I am not happy with the default titling of a link (the website title). F.e. I want to save links to job postings but don't want the website title of the recruitment platform as the link title.

With this feature you can add a custom title to the link (optional - then the default way of titling will be used).
Also I changed the UI of the Update-Title component input element for UX reasons. First I haven't understand that I can change the title because of the similarity of the title input element to a normal headline.

### Changelog
- update styling of Update-Link title input tag
- add Link Titling by client on creation